### PR TITLE
Support replacing exceptions' backtrace with power_trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,21 @@ I don't recommend using it like this for other purposes, though. Because by defa
 - `colorize` - to decide whether to colorize each entry in their string format. Default is `true`.
 - `line_limit` - `power_trace` truncates every argument/local variable's value to avoid creating too much noise. Default is `100`
 
-### Get `power_trace` From An Exception (Experimental)
+### Use It With StandardError (Experimental)
 
-You can also access an exception object's enhanced backtrace with the `power_trace` method:
+If you set 
+
+```ruby
+PowerTrace.replace_backtrace = true
+```
+
+it will replace every `StandardError` exception's backtrace with the `power_trace.to_backtrace`. So most of the error traces you see will also contain the colorized environment information!
+
+This is still an experimental feature for now, as it has a very wide impact on all the libraries and your own code. **Don't try this on production!!!!**
+
+#### Get `power_trace` Manually From A StandardError Exception
+
+If you think the above feature is too aggressive. You can access an exception object's enhanced backtrace manually with the `power_trace` method:
 
 ```ruby
 begin
@@ -95,7 +107,7 @@ rescue => e
 end
 ```
 
-And use it as you get it from the call site.
+This feature doesn't require any flag to enable, as the information is added as an extra field and doesn't override anything.
 
 ## Inspirations & Helpful Tools
 

--- a/lib/power_trace.rb
+++ b/lib/power_trace.rb
@@ -2,6 +2,11 @@ require "power_trace/version"
 require "power_trace/stack"
 
 module PowerTrace
+  cattr_accessor :replace_backtrace, instance_accessor: false
+  cattr_accessor :colorize_backtrace, instance_accessor: false
+  self.replace_backtrace = false
+  self.colorize_backtrace = true
+
   def power_trace(options = {})
     PowerTrace::Stack.new(options)
   end

--- a/lib/power_trace/exception_patch.rb
+++ b/lib/power_trace/exception_patch.rb
@@ -1,14 +1,23 @@
-class Exception
+class StandardError
   attr_accessor :power_trace
 end
 
 TracePoint.trace(:raise) do |tp|
   begin
     e = tp.raised_exception
+
+    next unless e.is_a?(StandardError)
+
     e.power_trace = power_trace(exception: true)
+
+    if PowerTrace.replace_backtrace
+      next if e.is_a?(LoadError)
+      next if e.is_a?(NameError)
+      e.set_backtrace(e.power_trace.to_backtrace(colorize: PowerTrace.colorize_backtrace))
+    end
   rescue => e
-    puts e
-    puts e.backtrace
-    fail "power_trace BUG"
+    puts(e)
+    puts(e.backtrace)
+    puts("power_trace's BUG")
   end
 end

--- a/spec/exceptions_spec.rb
+++ b/spec/exceptions_spec.rb
@@ -47,4 +47,21 @@ RSpec.describe PowerTrace do
   it "inserts power_trace to exceptions" do
     expect(exception.power_trace.to_s(colorize: false)).to match(expected_power_trace)
   end
+
+  context "when PowerTrace.replace_backtrace = true" do
+    around do |example|
+      begin
+        PowerTrace.replace_backtrace = true
+        PowerTrace.colorize_backtrace = false
+
+        example.run
+      ensure
+        PowerTrace.replace_backtrace = false
+        PowerTrace.colorize_backtrace = true
+      end
+    end
+    it "replaces error's backtrace" do
+      expect(exception.backtrace.join("\n")).to match(expected_power_trace)
+    end
+  end
 end


### PR DESCRIPTION
1. This feature is **disabled** by default. Users can enable it with `PowerTrace.replace_backtrace = true`.
2. This feature also comes from `PowerTrace.colorize_backtrace` option. Users can use it to decide if the power_trace should be colorized or not. Default is `true`.
