### PR TITLE
Improve exception output

### DIFF
--- a/lib/power_trace/entry.rb
+++ b/lib/power_trace/entry.rb
@@ -95,13 +95,13 @@ module PowerTrace
 
     def hash_to_string(hash, inspect, options)
       truncation = options[:line_limit]
-      indent = "\s" * options[:extra_info_indent]
+      indentation = options[:indentation] + "\s" * 2
 
       elements_string = hash.map do |key, value|
         value_string = value_to_string(value, truncation)
         "#{key.to_s}: #{value_string}"
-      end.join("\n#{indent}")
-      "#{indent}#{elements_string}"
+      end.join("\n#{indentation}")
+      "#{indentation}#{elements_string}"
     end
 
     def value_to_string(value, truncation)

--- a/lib/power_trace/entry.rb
+++ b/lib/power_trace/entry.rb
@@ -6,8 +6,6 @@ module PowerTrace
     include ColorizeHelper
     UNDEFINED = "[undefined]"
 
-    INDENT = "\s" * 4
-
     attr_reader :frame, :filepath, :line_number, :receiver, :locals, :arguments
 
     def initialize(frame)
@@ -27,11 +25,17 @@ module PowerTrace
     end
 
     def arguments_string(options = {})
-      hash_to_string(arguments, false, options[:line_limit])
+      <<~STR.chomp
+        #{options[:indentation]}(Arguments)
+        #{hash_to_string(arguments, false, options)}
+      STR
     end
 
     def locals_string(options = {})
-      hash_to_string(locals, false, options[:line_limit])
+      <<~STR.chomp
+        #{options[:indentation]}(Locals)
+        #{hash_to_string(locals, false, options)}
+      STR
     end
 
     def call_trace(options = {})
@@ -61,7 +65,9 @@ module PowerTrace
     end
 
     def to_s(options = {})
-      assemble_string(options)
+      # this is to prevent entries from polluting each other's options
+      # of course, that'd only happen if I did something stupid ;)
+      assemble_string(options.dup)
     end
 
     private
@@ -73,29 +79,29 @@ module PowerTrace
     def assemble_string(options)
       strings = [call_trace(options)]
 
+      indentation = "\s" * options[:extra_info_indent]
+      options[:indentation] = indentation
+
       if arguments.present?
-        strings << <<~STR.chomp
-            (Arguments)
-        #{arguments_string(options)}
-        STR
+        strings << arguments_string(options)
       end
 
       if locals.present?
-        strings << <<~STR.chomp
-            (Locals)
-        #{locals_string(options)}
-        STR
+        strings << locals_string(options)
       end
 
       strings.join("\n")
     end
 
-    def hash_to_string(hash, inspect, truncation)
+    def hash_to_string(hash, inspect, options)
+      truncation = options[:line_limit]
+      indent = "\s" * options[:extra_info_indent]
+
       elements_string = hash.map do |key, value|
         value_string = value_to_string(value, truncation)
         "#{key.to_s}: #{value_string}"
-      end.join("\n#{INDENT}")
-      "#{INDENT}#{elements_string}"
+      end.join("\n#{indent}")
+      "#{indent}#{elements_string}"
     end
 
     def value_to_string(value, truncation)

--- a/lib/power_trace/entry.rb
+++ b/lib/power_trace/entry.rb
@@ -43,10 +43,10 @@ module PowerTrace
     end
 
     ATTRIBUTE_COLORS = {
-      name: COLORS[:blue],
-      location: COLORS[:green],
-      arguments_string: COLORS[:orange],
-      locals_string: COLORS[:megenta]
+      name: :blue,
+      location: :green,
+      arguments_string: :orange,
+      locals_string: :megenta
     }
 
     ATTRIBUTE_COLORS.each do |attribute, color|
@@ -57,7 +57,7 @@ module PowerTrace
         call_result = send("original_#{attribute}", options)
 
         if options[:colorize]
-          "#{color}#{call_result}#{COLORS[:reset]}"
+          send("#{color}_color", call_result)
         else
           call_result
         end

--- a/lib/power_trace/helpers/colorize_helper.rb
+++ b/lib/power_trace/helpers/colorize_helper.rb
@@ -17,12 +17,5 @@ module PowerTrace
         "#{color_mark}#{str}#{RESET_MARK}"
       end
     end
-
-    COLORS = COLOR_CODES.each_with_object({}) do |(name, code), hash|
-      hash[name] = "\u001b[38;5;#{code}m"
-    end.merge(
-      reset: "\u001b[0m",
-      nocolor: ""
-    )
   end
 end

--- a/lib/power_trace/stack.rb
+++ b/lib/power_trace/stack.rb
@@ -9,7 +9,8 @@ module PowerTrace
 
     OUTPUT_OPTIONS_DEFAULT = {
       colorize: true,
-      line_limit: 100
+      line_limit: 100,
+      extra_info_indent: 4
     }
 
     def initialize(options = {})

--- a/spec/exceptions_spec.rb
+++ b/spec/exceptions_spec.rb
@@ -48,6 +48,28 @@ RSpec.describe PowerTrace do
     expect(exception.power_trace.to_s(colorize: false)).to match(expected_power_trace)
   end
 
+  context "with extra_info_indent: Int" do
+    let(:expected_power_trace) do
+/.*:\d+:in `forth_call'
+        \(Arguments\)
+        num1: 20
+        num2: 10
+.*:\d+:in `block in second_call'
+        \(Locals\)
+        ten: 10
+        num: 20
+.*:\d+:in `third_call_with_block'
+        \(Arguments\)
+        block: #<Proc:.*@.*:\d+>
+.*:\d+:in `second_call'
+        \(Arguments\)
+        num: 20/
+    end
+    it "indents the extra information according to the given value" do
+      expect(exception.power_trace.to_s(colorize: false, extra_info_indent: 8)).to match(expected_power_trace)
+    end
+  end
+
   context "when PowerTrace.replace_backtrace = true" do
     around do |example|
       begin

--- a/spec/exceptions_spec.rb
+++ b/spec/exceptions_spec.rb
@@ -2,18 +2,18 @@ RSpec.describe PowerTrace do
   let(:expected_power_trace) do
 /.*:\d+:in `forth_call'
     \(Arguments\)
-    num1: 20
-    num2: 10
+      num1: 20
+      num2: 10
 .*:\d+:in `block in second_call'
     \(Locals\)
-    ten: 10
-    num: 20
+      ten: 10
+      num: 20
 .*:\d+:in `third_call_with_block'
     \(Arguments\)
-    block: #<Proc:.*@.*:\d+>
+      block: #<Proc:.*@.*:\d+>
 .*:\d+:in `second_call'
     \(Arguments\)
-    num: 20/
+      num: 20/
   end
 
   let(:expected_backtrace) do
@@ -52,18 +52,18 @@ RSpec.describe PowerTrace do
     let(:expected_power_trace) do
 /.*:\d+:in `forth_call'
         \(Arguments\)
-        num1: 20
-        num2: 10
+          num1: 20
+          num2: 10
 .*:\d+:in `block in second_call'
         \(Locals\)
-        ten: 10
-        num: 20
+          ten: 10
+          num: 20
 .*:\d+:in `third_call_with_block'
         \(Arguments\)
-        block: #<Proc:.*@.*:\d+>
+          block: #<Proc:.*@.*:\d+>
 .*:\d+:in `second_call'
         \(Arguments\)
-        num: 20/
+          num: 20/
     end
     it "indents the extra information according to the given value" do
       expect(exception.power_trace.to_s(colorize: false, extra_info_indent: 8)).to match(expected_power_trace)

--- a/spec/power_trace_spec.rb
+++ b/spec/power_trace_spec.rb
@@ -2,18 +2,18 @@ RSpec.describe PowerTrace do
   let(:expected_output) do
 /.*:\d+:in `forth_call'
     \(Arguments\)
-    num1: 20
-    num2: 10
+      num1: 20
+      num2: 10
 .*:\d+:in `block in second_call'
     \(Locals\)
-    ten: 10
-    num: 20
+      ten: 10
+      num: 20
 .*:\d+:in `third_call_with_block'
     \(Arguments\)
-    block: #<Proc:.*@.*:\d+>
+      block: #<Proc:.*@.*:\d+>
 .*:\d+:in `second_call'
     \(Arguments\)
-    num: 20/
+      num: 20/
   end
 
   it "prints traces correctly" do


### PR DESCRIPTION
1. Add `extra_info_indent` option to allow adjusting the indentation on the additional info (locals/arguments) sections.
2. Some cleanup on the output colorizing.

Current output
<img width="735" alt="截圖 2020-07-12 下午8 28 55" src="https://user-images.githubusercontent.com/5079556/87246190-50476100-c47e-11ea-9095-451bfdd44bbf.png">
